### PR TITLE
Fix Pinecone demo API key handling

### DIFF
--- a/pinecone_demo.py
+++ b/pinecone_demo.py
@@ -1,8 +1,8 @@
 # Import the Pinecone library
 from pinecone import Pinecone
+import os
 
-# Initialize a Pinecone client with your API key
-pc = Pinecone(api_key="pcsk_3UQjbP_CmGxVJFcUvPuz25jWB2gYJHAVEwtMTUaXV58rbokW4CYeQBjCVTcX912oEebK4k")
+pc = Pinecone(api_key=os.environ.get("PINECONE_API_KEY"))
 
 # Create a dense index with integrated embedding
 index_name = "quickstart-demo-py"


### PR DESCRIPTION
## Summary
- load Pinecone API key from `PINECONE_API_KEY` environment variable
- ensure pinecone_demo.py ends with a newline

## Testing
- `python3 -m py_compile pinecone_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68504379d728832da3b324052989f970